### PR TITLE
fix(compose,docs): correct metrics-collector image and remove stale S…

### DIFF
--- a/smart-kiosk-assistant/.env.example
+++ b/smart-kiosk-assistant/.env.example
@@ -125,5 +125,6 @@ BOOTSTRAP_ON_START=true
 #     https://www.pexels.com/video/young-people-standing-in-line-to-promote-equality-10617738/
 # =============================================================================
 SAMPLE_DATA_DIR=./Sample_data
-SAMPLE_VIDEO_1_URL=https://www.pexels.com/video/performance-promoting-equality-concept-10617615/
-SAMPLE_VIDEO_2_URL=https://www.pexels.com/video/young-people-standing-in-line-to-promote-equality-10617738/
+SAMPLE_VIDEO_1_URL=https://videos.pexels.com/video-files/10617615/10617615-uhd_4096_2160_25fps.mp4
+SAMPLE_VIDEO_2_URL=https://videos.pexels.com/video-files/10617738/10617738-uhd_4096_2160_25fps.mp4
+ 

--- a/smart-kiosk-assistant/docker-compose.yml
+++ b/smart-kiosk-assistant/docker-compose.yml
@@ -118,7 +118,7 @@ services:
       dockerfile: Dockerfile
     # Pinned independently of RELEASE_TAG: metrics-collector is excluded from
     # this release cycle, so it stays on the last released image.
-    image: ${REGISTRY:-intel}/metrics-collector:2026.1.0
+    image: ${REGISTRY:-intel}/hl-ai-metrics-collector:2026.1.0
     container_name: metrics-collector
     privileged: true
     pid: host

--- a/smart-kiosk-assistant/docs/user-guide/get-started.md
+++ b/smart-kiosk-assistant/docs/user-guide/get-started.md
@@ -74,23 +74,7 @@ git clone https://github.com/intel-retail/voice-enabled-interactions.git
 cd voice-enabled-interactions/smart-kiosk-assistant
 ```
 
-## Step 3: Clone `edge-ai-libraries` (Audio and TTS Source)
-
-The `audio-analyzer` and `text-to-speech` images are built from the
-[edge-ai-libraries](https://github.com/open-edge-platform/edge-ai-libraries)
-monorepo. The compose file expects them at `../edge-ai-libraries/microservices/`,
-so both repositories must sit side by side:
-
-```bash
-cd ..   # move to the parent directory that contains voice-enabled-interactions
-git clone --depth 1 --filter=blob:none --sparse \
-    https://github.com/open-edge-platform/edge-ai-libraries.git
-git -C edge-ai-libraries sparse-checkout set \
-    microservices/audio-analyzer microservices/text-to-speech
-cd voice-enabled-interactions/smart-kiosk-assistant
-```
-
-## Step 4:Create `.env` and Set Required Variables
+## Step 3: Create `.env` and Set Required Variables
 
 Create your environment file from the template:
 
@@ -119,7 +103,7 @@ getent group render | cut -d: -f3
 
 Set `TARGET_DEVICE=CPU` in `.env` if no Intel GPU is available.
 
-## Step 5: Download the LLM Model for OVMS
+## Step 4: Download the LLM Model for OVMS
 
 The ordering agent uses a Qwen3-4B model served by OVMS. Download it
 before starting the stack:
@@ -139,7 +123,7 @@ The script downloads the pre-converted OpenVINO model into `./models/`
 and updates `OVMS_MODEL_NAME`, `TARGET_DEVICE`, and `RENDER_GID` in `.env`.
 The download happens once — subsequent starts reuse the cached model.
 
-## Step 6: Download Sample Videos for Queue Analytics
+## Step 5: Download Sample Videos for Queue Analytics
 
 The `queue-service` person-counting pipeline consumes an RTSP stream published
 by `rtsp-streamer` from clips under `Sample_data/`. Set the download URLs in
@@ -153,7 +137,7 @@ The clips are saved as `Sample_data/sample_1.mp4` and `Sample_data/sample_2.mp4`
 to match the `MEDIA_FILES` entry in `docker-compose.yml`. You can also copy your
 own MP4 files to those paths manually.
 
-## Step 7: Build Images and Start the Stack
+## Step 6: Build Images and Start the Stack
 
 ```bash
 make build           # build local images (or `make build REGISTRY=true` to pull)
@@ -192,7 +176,7 @@ starts only when identity is enabled:
 make up IDENTITY=true
 ```
 
-## Step 8: Verify the Stack Is Healthy
+## Step 7: Verify the Stack Is Healthy
 
 Services start in dependency order. Allow 2–5 minutes on first run for
 model assets to download into Docker volumes.
@@ -217,7 +201,7 @@ curl --noproxy '*' http://127.0.0.1:8090/health       # queue-service
 Every health endpoint should return `{"status": "ok"}`. The OVMS endpoint
 returns the active model name (`OpenVINO/Qwen3-4B-int8-ov`).
 
-## Step 9: Open the Kiosk and Try Voice Ordering
+## Step 8: Open the Kiosk and Try Voice Ordering
 
 Open a browser on the same machine:
 


### PR DESCRIPTION
…tep 3

docker-compose.yml:
- Fix metrics-collector image name from intel/metrics-collector:2026.1.0 (does not exist on Docker Hub) to intel/hl-ai-metrics-collector:2026.1.0

docs/user-guide/get-started.md:
- Remove Step 3 (Clone edge-ai-libraries) — audio-analyzer and text-to-speech are now pulled as pre-built images from the registry, so cloning the source monorepo is no longer required
- Renumber Steps 4–9 → Steps 3–8 to keep the sequence continuous