### PR TITLE
Make camera device optional for sample RTSP mode

### DIFF
--- a/smart-kiosk-assistant/.env.example
+++ b/smart-kiosk-assistant/.env.example
@@ -116,6 +116,11 @@ BOOTSTRAP_ON_START=true
 #
 # CAMERA_DEVICE — V4L2 device node used only by live mode.
 #   Required when RTSP_SOURCE_MODE=live.
+#
+# Internal variables (computed by Makefile, do not edit):
+#   RTSP_CAMERA_DEVICE — resolved by Makefile to /dev/null in sample mode,
+#     or to CAMERA_DEVICE value in live mode. Automatically passed to docker
+#     compose. Users should not set this directly.
 # =============================================================================
 RTSP_SOURCE_MODE=sample
 CAMERA_DEVICE=

--- a/smart-kiosk-assistant/.env.example
+++ b/smart-kiosk-assistant/.env.example
@@ -114,11 +114,11 @@ BOOTSTRAP_ON_START=true
 #   sample -> bundled sample clips from SAMPLE_DATA_DIR are streamed
 #   live   -> the configured CAMERA_DEVICE is streamed via V4L2
 #
-# CAMERA_DEVICE — V4L2 device node used by live mode. The same value is used
-#   for the container device mapping in docker-compose.yml.
+# CAMERA_DEVICE — V4L2 device node used only by live mode.
+#   Required when RTSP_SOURCE_MODE=live.
 # =============================================================================
 RTSP_SOURCE_MODE=sample
-CAMERA_DEVICE=/dev/video0
+CAMERA_DEVICE=
 
 # =============================================================================
 # [Optional] V4L2 Camera Capture Settings

--- a/smart-kiosk-assistant/Makefile
+++ b/smart-kiosk-assistant/Makefile
@@ -47,6 +47,21 @@ SAMPLE_DATA_DIR    ?= ./Sample_data
 SAMPLE_VIDEO_1_URL ?=
 SAMPLE_VIDEO_2_URL ?=
 
+# RTSP source mode and camera mount resolution.
+# Compose cannot conditionally include devices, so we resolve one effective
+# host device path here and pass it as RTSP_CAMERA_DEVICE:
+#   sample -> /dev/null (safe no-op mapping)
+#   live   -> CAMERA_DEVICE (must be set and valid)
+# Strip whitespace from both to tolerate trailing spaces in .env.
+_ENV_RTSP_SOURCE_MODE := $(RTSP_SOURCE_MODE)
+RTSP_SOURCE_MODE      ?= $(_ENV_RTSP_SOURCE_MODE)
+_RTSP_SOURCE_MODE_RAW  = $(strip $(RTSP_SOURCE_MODE))
+_RTSP_SOURCE_MODE      = $(if $(_RTSP_SOURCE_MODE_RAW),$(_RTSP_SOURCE_MODE_RAW),sample)
+_RTSP_LIVE_ON          = $(filter live,$(_RTSP_SOURCE_MODE))
+_CAMERA_DEVICE_RAW     = $(strip $(CAMERA_DEVICE))
+_RTSP_CAMERA_DEVICE    = $(if $(_RTSP_LIVE_ON),$(_CAMERA_DEVICE_RAW),/dev/null)
+COMPOSE_BASE           = RTSP_SOURCE_MODE=$(_RTSP_SOURCE_MODE) RTSP_CAMERA_DEVICE=$(_RTSP_CAMERA_DEVICE) docker compose -f $(COMPOSE_FILE)
+
 # Services with fully local build contexts
 LOCAL_ONLY_SERVICES := metrics-collector rag-service kiosk-core kiosk-ui queue-service rtsp-streamer
 
@@ -235,6 +250,33 @@ check-env: ## Validate .env and all required variables before running the stack
 		echo "  $(GREEN)✓ TARGET_DEVICE=$(TARGET_DEVICE)$(NC)"; \
 	fi; \
 	\
+	if [ "$(_RTSP_SOURCE_MODE_RAW)" != "" ] && [ "$(_RTSP_SOURCE_MODE_RAW)" != "sample" ] && [ "$(_RTSP_SOURCE_MODE_RAW)" != "live" ]; then \
+		echo "  $(RED)✗ RTSP_SOURCE_MODE='$(_RTSP_SOURCE_MODE_RAW)' is invalid$(NC)  (must be sample | live)"; \
+		ERRORS=$$((ERRORS+1)); \
+	else \
+		echo "  $(GREEN)✓ RTSP_SOURCE_MODE=$(_RTSP_SOURCE_MODE)$(NC)"; \
+	fi; \
+	\
+	if [ "$(_RTSP_SOURCE_MODE)" = "live" ]; then \
+		if [ -z "$(_CAMERA_DEVICE_RAW)" ]; then \
+			echo "  $(RED)✗ CAMERA_DEVICE is not set$(NC)  (required when RTSP_SOURCE_MODE=live)"; \
+			ERRORS=$$((ERRORS+1)); \
+		elif [ ! -e "$(_CAMERA_DEVICE_RAW)" ]; then \
+			echo "  $(RED)✗ CAMERA_DEVICE='$(_CAMERA_DEVICE_RAW)' does not exist$(NC)"; \
+			ERRORS=$$((ERRORS+1)); \
+		elif [ ! -r "$(_CAMERA_DEVICE_RAW)" ]; then \
+			echo "  $(RED)✗ CAMERA_DEVICE='$(_CAMERA_DEVICE_RAW)' is not readable$(NC)"; \
+			ERRORS=$$((ERRORS+1)); \
+		elif [ ! -c "$(_CAMERA_DEVICE_RAW)" ]; then \
+			echo "  $(RED)✗ CAMERA_DEVICE='$(_CAMERA_DEVICE_RAW)' is not a character device$(NC)"; \
+			ERRORS=$$((ERRORS+1)); \
+		else \
+			echo "  $(GREEN)✓ CAMERA_DEVICE=$(_CAMERA_DEVICE_RAW)$(NC)"; \
+		fi; \
+	else \
+		echo "  $(GREEN)✓ CAMERA_DEVICE is optional in sample mode$(NC)"; \
+	fi; \
+	\
 	if [ "$(TARGET_DEVICE)" = "GPU" ]; then \
 		if [ -z "$(RENDER_GID)" ]; then \
 			echo "  $(RED)✗ RENDER_GID is not set$(NC)  (required for GPU access inside containers)"; \
@@ -283,6 +325,11 @@ show-config: ## Print resolved configuration
 	@echo "$(YELLOW)Authentication:$(NC)"
 	@echo "  HF_TOKEN          = $$([ -n '$(HF_TOKEN)' ] && echo '***set***' || echo 'NOT SET')"
 	@echo ""
+	@echo "$(YELLOW)RTSP source:$(NC)"
+	@echo "  RTSP_SOURCE_MODE  = $(_RTSP_SOURCE_MODE)"
+	@echo "  CAMERA_DEVICE     = $$([ -n '$(_CAMERA_DEVICE_RAW)' ] && echo '$(_CAMERA_DEVICE_RAW)' || echo '(unset)')"
+	@echo "  RTSP_CAMERA_DEVICE= $(_RTSP_CAMERA_DEVICE)"
+	@echo ""
 	@echo "$(YELLOW)Identity feature:$(NC)"
 	@echo "  IDENTITY          = $(IDENTITY)  (from .env KIOSK_CORE_IDENTITY_ENABLED, override with IDENTITY=true|false)"
 	@echo "  identity-service  = $$([ -n '$(_IDENTITY_SVC)' ] && echo 'enabled — will start with --profile identity' || echo 'disabled')"
@@ -296,17 +343,17 @@ build: check-env ## Build (REGISTRY=false) or pull (REGISTRY=true) all images
 	@echo "$(BLUE)Preparing Docker images...$(NC)"
 	@if [ "$(REGISTRY)" = "false" ] || [ "$(REGISTRY)" = "FALSE" ]; then \
 		echo "$(YELLOW)  REGISTRY=false → Building local services from source$(NC)"; \
-		REGISTRY=$(_DOCKER_REGISTRY) docker compose -f $(COMPOSE_FILE) $(_IDENTITY_PROFILE) build $(LOCAL_ONLY_SERVICES) $(_IDENTITY_SVC); \
+		REGISTRY=$(_DOCKER_REGISTRY) $(COMPOSE_BASE) $(_IDENTITY_PROFILE) build $(LOCAL_ONLY_SERVICES) $(_IDENTITY_SVC); \
 	else \
 		echo "$(YELLOW)  REGISTRY=$(REGISTRY) → Pulling images from registry$(NC)"; \
-		REGISTRY=$(REGISTRY) docker compose -f $(COMPOSE_FILE) pull $(LOCAL_ONLY_SERVICES); \
+		REGISTRY=$(REGISTRY) $(COMPOSE_BASE) pull $(LOCAL_ONLY_SERVICES); \
 		if [ -n "$(_IDENTITY_SVC)" ]; then \
 			echo "$(YELLOW)  Building identity-service locally (no registry image)...$(NC)"; \
-			REGISTRY=$(_DOCKER_REGISTRY) docker compose -f $(COMPOSE_FILE) $(_IDENTITY_PROFILE) build identity-service; \
+			REGISTRY=$(_DOCKER_REGISTRY) $(COMPOSE_BASE) $(_IDENTITY_PROFILE) build identity-service; \
 		fi; \
 	fi; \
 	echo "$(YELLOW)  Pulling audio-analyzer, text-to-speech from Docker Hub (edge-ai-libraries — separate repo, no local build)...$(NC)"; \
-	REGISTRY=$(_DOCKER_REGISTRY) docker compose -f $(COMPOSE_FILE) pull $(REGISTRY_ONLY_SERVICES)
+	REGISTRY=$(_DOCKER_REGISTRY) $(COMPOSE_BASE) pull $(REGISTRY_ONLY_SERVICES)
 	@echo "$(GREEN)✓ Images ready$(NC)"
 
 # =============================================================================
@@ -315,7 +362,7 @@ build: check-env ## Build (REGISTRY=false) or pull (REGISTRY=true) all images
 
 up: check-env setup-dirs ## Start all services
 	@echo "$(BLUE)Starting Smart Kiosk Assistant...$(NC)"
-	REGISTRY=$(_DOCKER_REGISTRY) docker compose -f $(COMPOSE_FILE) $(_IDENTITY_PROFILE) up -d
+	REGISTRY=$(_DOCKER_REGISTRY) $(COMPOSE_BASE) $(_IDENTITY_PROFILE) up -d
 	@echo ""
 	@echo "$(GREEN)✓ Stack started$(NC)"
 	@echo "  Kiosk UI        → http://localhost:7860"
@@ -329,7 +376,7 @@ up: check-env setup-dirs ## Start all services
 
 down: ## Stop all services
 	@echo "$(BLUE)Stopping Smart Kiosk Assistant...$(NC)"
-	docker compose -f $(COMPOSE_FILE) $(_IDENTITY_PROFILE) down
+	$(COMPOSE_BASE) $(_IDENTITY_PROFILE) down
 	@echo "$(GREEN)✓ All services stopped$(NC)"
 
 restart: down up ## Stop then restart all services
@@ -340,7 +387,7 @@ restart: down up ## Stop then restart all services
 
 status: ## Show container status
 	@echo "$(BLUE)Container Status:$(NC)"
-	@docker compose -f $(COMPOSE_FILE) ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}"
+	@$(COMPOSE_BASE) ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}"
 
 # =============================================================================
 # Health Tests
@@ -387,7 +434,7 @@ test: ## Run health checks on all service endpoints
 # =============================================================================
 
 logs: ## Tail logs for all services
-	docker compose -f $(COMPOSE_FILE) logs -f
+	$(COMPOSE_BASE) logs -f
 
 logs-ovms: ## Tail ovms-llm logs
 	docker logs -f ovms-llm
@@ -423,8 +470,8 @@ dev-build: ## Rebuild and restart a single service: make dev-build SVC=rag-servi
 		exit 1; \
 	fi
 	@echo "$(BLUE)Rebuilding $(SVC)...$(NC)"
-	docker compose -f $(COMPOSE_FILE) build $(SVC)
-	docker compose -f $(COMPOSE_FILE) up -d $(SVC)
+	$(COMPOSE_BASE) build $(SVC)
+	$(COMPOSE_BASE) up -d $(SVC)
 	@echo "$(GREEN)✓ $(SVC) rebuilt and restarted$(NC)"
 
 # =============================================================================
@@ -433,6 +480,6 @@ dev-build: ## Rebuild and restart a single service: make dev-build SVC=rag-servi
 
 clean: ## Stop containers and remove named volumes
 	@echo "$(BLUE)Stopping services and removing volumes...$(NC)"
-	docker compose -f $(COMPOSE_FILE) down -v
+	$(COMPOSE_BASE) down -v
 	@echo "$(GREEN)✓ Containers stopped and volumes removed$(NC)"
 	@echo "  Note: models/ directory is preserved. Delete it manually to free ~4 GB."

--- a/smart-kiosk-assistant/docker-compose.yml
+++ b/smart-kiosk-assistant/docker-compose.yml
@@ -39,22 +39,20 @@ services:
       # Sample mode uses the existing MEDIA_FILES / MEDIA_FILE branches.
       # The bundled clips are mounted from ./Sample_data into /media.
       MEDIA_FILES:    ${MEDIA_FILES:-sample_1.mp4,sample_2.mp4}
-      # Live mode uses the same configurable device path for both the mount
-      # and the ffmpeg input. Sample mode ignores this value.
-      CAMERA_DEVICE:  ${CAMERA_DEVICE:-/dev/video0}
+      # Live mode reads from this V4L2 node. Sample mode ignores this value.
+      CAMERA_DEVICE:  ${CAMERA_DEVICE:-}
       STREAM_NAME:    ${STREAM_NAME:-queue}
       RTSP_PORT:      "8554"
       LOOP_COUNT:     "-1"      # -1 = infinite loop for a continuous feed
       BLANK_DURATION: "0"       # seconds of black frames between loops
       NO_PROXY: "localhost,127.0.0.1,rtsp-streamer,queue-management,kiosk-core"
       no_proxy: "localhost,127.0.0.1,rtsp-streamer,queue-management,kiosk-core"
-    # Device mapping is required for RTSP_SOURCE_MODE=live. Docker Compose does
-    # not support conditional device mappings, so this is always present. In
-    # sample mode, the device is not accessed by ffmpeg (sample files are used),
-    # so no permission errors occur. In live mode, this grants the container
-    # read access to the V4L2 camera device.
+    # Compose cannot conditionally include devices. RTSP_CAMERA_DEVICE is
+    # therefore resolved outside compose:
+    #   sample mode -> /dev/null (safe on systems without a camera)
+    #   live mode   -> CAMERA_DEVICE (validated by check-env/start.sh)
     devices:
-      - ${CAMERA_DEVICE:-/dev/video0}:${CAMERA_DEVICE:-/dev/video0}
+      - ${RTSP_CAMERA_DEVICE:-/dev/null}:${RTSP_CAMERA_DEVICE:-/dev/null}
     group_add:
       - video
     volumes:

--- a/smart-kiosk-assistant/rtsp-streamer/start.sh
+++ b/smart-kiosk-assistant/rtsp-streamer/start.sh
@@ -115,6 +115,11 @@ if [ "$RTSP_SOURCE_MODE" = live ]; then
     camera_device_troubleshooting "<unset>"
     exit 1
   fi
+  if [ "$CAMERA_DEVICE" = "/dev/null" ]; then
+    log "ERROR CAMERA_DEVICE is '/dev/null'. Set a real V4L2 node when RTSP_SOURCE_MODE=live (for example /dev/video0)." >&2
+    camera_device_troubleshooting "$CAMERA_DEVICE"
+    exit 1
+  fi
   if [ ! -e "$CAMERA_DEVICE" ]; then
     camera_device_troubleshooting "$CAMERA_DEVICE"
     exit 1

--- a/smart-kiosk-assistant/tests/functional/test_env_validation.py
+++ b/smart-kiosk-assistant/tests/functional/test_env_validation.py
@@ -241,10 +241,11 @@ class TestDockerComposeEnvCompleteness:
 
     # Variables that are intentionally injected at runtime (not in .env.example)
     RUNTIME_ONLY = {
-        "STREAM_NAME",      # set per rtsp-streamer container
-        "RENDER_GID",       # documented but may be omitted on CPU-only setups
-        "IDENTITY",         # optional feature flag, default false
-        "TAG",              # derived from RELEASE_TAG in Makefile
+        "STREAM_NAME",           # set per rtsp-streamer container
+        "RENDER_GID",            # documented but may be omitted on CPU-only setups
+        "IDENTITY",              # optional feature flag, default false
+        "TAG",                   # derived from RELEASE_TAG in Makefile
+        "RTSP_CAMERA_DEVICE",    # computed by Makefile based on RTSP_SOURCE_MODE and CAMERA_DEVICE
     }
 
     @pytest.mark.tier1


### PR DESCRIPTION
## Summary

This PR updates the RTSP streamer configuration so that CAMERA_DEVICE is required only in live mode.

## Changes

- Updated .env.example to make CAMERA_DEVICE optional in sample mode.
- Updated docker-compose.yml to use mode-based device mapping.
- Updated the Makefile to validate RTSP_SOURCE_MODE and CAMERA_DEVICE.
- Updated start.sh to improve validation and error handling.

## Validation

Sample mode:
- Verified that the application runs successfully on systems without camera support.
- Confirmed that no manual changes are required.

Live mode:
- Verified that CAMERA_DEVICE validation works correctly.
- Confirmed that an appropriate error is shown when the device is unavailable.