### PR TITLE
Update transformers to 5.3.0 and fix RAG service tests

### DIFF
--- a/smart-kiosk-assistant/rag-service/requirements.txt
+++ b/smart-kiosk-assistant/rag-service/requirements.txt
@@ -11,21 +11,21 @@ python-docx==1.1.2
 pypdf==4.3.1
 
 openvino==2026.1.0
-openvino-tokenizers
-optimum==1.26.1
-optimum-intel==1.24.0
+openvino-tokenizers==2026.1.0.0
+optimum==2.3.0
+optimum-intel==2.1.0
 nncf==2.19.0
 
-huggingface-hub==0.34.4
+huggingface-hub==1.21.0
 fsspec>=2023.1.0,<=2025.3.0
 
 numpy==1.26.4
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.8.0+cpu
-transformers==4.52.4
-tokenizers==0.21.4
+transformers==5.3.0
+tokenizers==0.22.2
 safetensors==0.6.2
-sentence-transformers==3.0.1
+sentence-transformers==5.2.0
 
 langchain-chroma>=0.2.5
 langchain-core>=0.3.74

--- a/smart-kiosk-assistant/rag-service/tests/conftest.py
+++ b/smart-kiosk-assistant/rag-service/tests/conftest.py
@@ -47,8 +47,6 @@ def reset_mcp_state() -> None:
 
     mcp_client._servers.clear()
     mcp_client._tools.clear()
-    mcp_client._session_ids.clear()
     yield
     mcp_client._servers.clear()
     mcp_client._tools.clear()
-    mcp_client._session_ids.clear()

--- a/smart-kiosk-assistant/rag-service/tests/test_knowledge_lookup_tool.py
+++ b/smart-kiosk-assistant/rag-service/tests/test_knowledge_lookup_tool.py
@@ -17,7 +17,7 @@ def _run(coro: Any) -> Any:
     return asyncio.run(coro)
 
 
-def test_knowledge_lookup_returns_streamed_rag_context(monkeypatch) -> None:
+def test_knowledge_lookup_returns_retrieved_rag_context(monkeypatch) -> None:
     """knowledge_lookup formats retrieved context from the shared RAG pipeline."""
 
     monkeypatch.setattr(knowledge_lookup_tool, "_PIN_ROOT_SECTION", False)

--- a/smart-kiosk-assistant/rag-service/tests/test_knowledge_lookup_tool.py
+++ b/smart-kiosk-assistant/rag-service/tests/test_knowledge_lookup_tool.py
@@ -6,7 +6,9 @@ import asyncio
 import sys
 import types
 from typing import Any
+from types import SimpleNamespace
 
+from agentic.tools import knowledge_lookup_tool
 from agentic.tools.knowledge_lookup_tool import knowledge_lookup
 
 
@@ -16,15 +18,20 @@ def _run(coro: Any) -> Any:
 
 
 def test_knowledge_lookup_returns_streamed_rag_context(monkeypatch) -> None:
-    """knowledge_lookup formats streamed tokens from the shared RAG pipeline."""
+    """knowledge_lookup formats retrieved context from the shared RAG pipeline."""
+
+    monkeypatch.setattr(knowledge_lookup_tool, "_PIN_ROOT_SECTION", False)
+    knowledge_lookup_tool.reset_pinned_context()
 
     class FakePipeline:
-        """Fake RAG pipeline with deterministic streaming output."""
+        """Fake RAG pipeline with deterministic retrieval output."""
 
-        def stream_answer(self, question: str, history: object | None = None) -> list[str]:
+        def iter_documents(self) -> list[str]:
+            return []
+
+        def retrieve(self, question: str):
             assert question == "What are your opening hours?"
-            assert history is None
-            return ["We are open ", "from 9am to 9pm."]
+            return [SimpleNamespace(content="We are open from 9am to 9pm.")]
 
     fake_pipeline = FakePipeline()
     pipeline_module = types.ModuleType("pipeline")
@@ -33,4 +40,4 @@ def test_knowledge_lookup_returns_streamed_rag_context(monkeypatch) -> None:
 
     answer = _run(knowledge_lookup("What are your opening hours?"))
 
-    assert answer == "We are open from 9am to 9pm."
+    assert "We are open from 9am to 9pm." in answer

--- a/smart-kiosk-assistant/rag-service/tests/test_mcp_client.py
+++ b/smart-kiosk-assistant/rag-service/tests/test_mcp_client.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import sys
+import types
 from typing import Any
+from types import SimpleNamespace
 
 from agentic import mcp_client
 
@@ -13,146 +16,144 @@ def _run(coro: Any) -> Any:
     return asyncio.run(coro)
 
 
+def _install_fake_mcp(monkeypatch, state: dict[str, Any]) -> None:
+    """Install fake mcp modules used by mcp_client imports."""
+
+    class _FakeStreamableHTTP:
+        def __init__(self, url: str) -> None:
+            self._url = url
+
+        async def __aenter__(self):
+            state["stream_urls"].append(self._url)
+            return ("read", "write", None)
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    class _FakeSession:
+        def __init__(self, read: str, write: str) -> None:
+            self.read = read
+            self.write = write
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def initialize(self) -> None:
+            state["initialized"] += 1
+
+        async def list_tools(self):
+            return SimpleNamespace(tools=state["tools"])
+
+        async def call_tool(self, tool_name: str, arguments: dict[str, Any]):
+            state["tool_calls"].append((tool_name, arguments))
+            if state.get("call_tool_error") is not None:
+                raise state["call_tool_error"]
+            delay = state.get("call_tool_delay", 0.0)
+            if delay:
+                await asyncio.sleep(delay)
+            return SimpleNamespace(content=state["result_content"])
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_mod.ClientSession = _FakeSession
+    client_mod = types.ModuleType("mcp.client")
+    stream_mod = types.ModuleType("mcp.client.streamable_http")
+    stream_mod.streamablehttp_client = lambda url: _FakeStreamableHTTP(url)
+
+    monkeypatch.setitem(sys.modules, "mcp", mcp_mod)
+    monkeypatch.setitem(sys.modules, "mcp.client", client_mod)
+    monkeypatch.setitem(sys.modules, "mcp.client.streamable_http", stream_mod)
+
+
 def test_discover_tools_lists_mcp_tools(monkeypatch, reset_mcp_state) -> None:
-    """discover_tools converts MCP tools/list JSON into MCPTool objects."""
+    """discover_tools converts MCP list_tools result into MCPTool objects."""
+    state = {
+        "stream_urls": [],
+        "initialized": 0,
+        "tool_calls": [],
+        "tools": [
+            SimpleNamespace(
+                name="place_order",
+                description="Create a draft order",
+                inputSchema={"type": "object", "properties": {"items": {"type": "array"}}},
+            )
+        ],
+        "result_content": [],
+    }
+    _install_fake_mcp(monkeypatch, state)
+
     server = mcp_client.MCPServerConfig(name="core", url="http://mcp.local")
-
-    async def fake_http_request(
-        requested_server: mcp_client.MCPServerConfig,
-        method: str,
-        params: dict[str, Any],
-    ) -> dict[str, Any]:
-        assert requested_server is server
-        assert method == "tools/list"
-        assert params == {}
-        return {
-            "tools": [
-                {
-                    "name": "place_order",
-                    "description": "Create a draft order",
-                    "inputSchema": {"type": "object", "properties": {"items": {"type": "array"}}},
-                }
-            ]
-        }
-
-    monkeypatch.setattr(mcp_client, "_http_request", fake_http_request)
-
     tools = _run(mcp_client.discover_tools(server))
 
+    assert state["stream_urls"] == ["http://mcp.local"]
+    assert state["initialized"] == 1
     assert [tool.name for tool in tools] == ["place_order"]
     assert tools[0].server == "core"
     assert tools[0].to_function_schema()["parameters"]["properties"]["items"]["type"] == "array"
 
 
 def test_call_tool_invokes_registered_tool_with_arguments(monkeypatch, reset_mcp_state) -> None:
-    """call_tool sends tools/call with the registered server and arguments."""
+    """call_tool uses the registered server and forwards args unchanged."""
+    state = {
+        "stream_urls": [],
+        "initialized": 0,
+        "tool_calls": [],
+        "tools": [],
+        "result_content": [SimpleNamespace(text='{"order_id":"ORD-1"}')],
+    }
+    _install_fake_mcp(monkeypatch, state)
+
     server = mcp_client.MCPServerConfig(name="core", url="http://mcp.local")
     mcp_client._servers["core"] = server
-    mcp_client._tools["place_order"] = mcp_client.MCPTool(
-        name="place_order",
-        server="core",
-        description="Create a draft order",
-    )
-    calls: list[dict[str, Any]] = []
-
-    async def fake_http_request(
-        requested_server: mcp_client.MCPServerConfig,
-        method: str,
-        params: dict[str, Any],
-    ) -> dict[str, Any]:
-        calls.append({"server": requested_server, "method": method, "params": params})
-        return {"content": [{"type": "text", "text": '{"order_id":"ORD-1"}'}]}
-
-    monkeypatch.setattr(mcp_client, "_http_request", fake_http_request)
+    mcp_client._tools["place_order"] = mcp_client.MCPTool(name="place_order", server="core")
 
     result = _run(mcp_client.call_tool("place_order", {"user_id": "u1", "items": []}))
 
     assert result == {"status": "success", "result": '{"order_id":"ORD-1"}'}
-    assert calls == [
-        {
-            "server": server,
-            "method": "tools/call",
-            "params": {"name": "place_order", "arguments": {"user_id": "u1", "items": []}},
-        }
-    ]
+    assert state["stream_urls"] == ["http://mcp.local"]
+    assert state["initialized"] == 1
+    assert state["tool_calls"] == [("place_order", {"user_id": "u1", "items": []})]
 
 
-def test_http_request_retries_once_after_stale_session(monkeypatch, reset_mcp_state) -> None:
-    """A stale 401/404 session ID is cleared and the request retried once."""
-    server = mcp_client.MCPServerConfig(name="core", url="http://mcp.local")
-    mcp_client._session_ids["core"] = "stale-session"
-    posts: list[dict[str, Any]] = []
-    responses = [
-        _FakeResponse(status=401, headers={}, payload={}),
-        _FakeResponse(status=200, headers={"mcp-session-id": "fresh-session"}, payload={"result": {"ok": True}}),
-    ]
+def test_call_tool_times_out(monkeypatch, reset_mcp_state) -> None:
+    """call_tool timeout returns an error payload instead of raising."""
+    state = {
+        "stream_urls": [],
+        "initialized": 0,
+        "tool_calls": [],
+        "tools": [],
+        "result_content": [SimpleNamespace(text="late")],
+        "call_tool_delay": 0.05,
+    }
+    _install_fake_mcp(monkeypatch, state)
 
-    class FakeClientSession:
-        """Fake aiohttp.ClientSession that returns scripted responses."""
+    server = mcp_client.MCPServerConfig(name="core", url="http://mcp.local", timeout=0.001)
+    mcp_client._servers["core"] = server
+    mcp_client._tools["confirm_order"] = mcp_client.MCPTool(name="confirm_order", server="core")
 
-        def __init__(self, *args: object, **kwargs: object) -> None:
-            self.args = args
-            self.kwargs = kwargs
-
-        async def __aenter__(self) -> "FakeClientSession":
-            return self
-
-        async def __aexit__(self, *args: object) -> None:
-            return None
-
-        def post(self, url: str, json: dict[str, Any], headers: dict[str, str]) -> "_FakeResponse":
-            posts.append({"url": url, "json": json, "headers": dict(headers)})
-            return responses.pop(0)
-
-    monkeypatch.setattr(mcp_client.aiohttp, "ClientSession", FakeClientSession)
-
-    result = _run(mcp_client._http_request(server, "tools/list", {}))
-
-    assert result == {"ok": True}
-    assert len(posts) == 2
-    assert posts[0]["headers"]["mcp-session-id"] == "stale-session"
-    assert "mcp-session-id" not in posts[1]["headers"]
-    assert mcp_client._session_ids["core"] == "fresh-session"
+    assert _run(mcp_client.call_tool("confirm_order", {"order_id": "ORD-1"})) == {
+        "error": "Tool confirm_order timed out"
+    }
 
 
 def test_call_tool_returns_error_payload_on_transport_failure(monkeypatch, reset_mcp_state) -> None:
-    """MCP tool transport errors are returned to the agent, not raised."""
+    """MCP transport errors are returned to the agent, not raised."""
+    state = {
+        "stream_urls": [],
+        "initialized": 0,
+        "tool_calls": [],
+        "tools": [],
+        "result_content": [],
+        "call_tool_error": RuntimeError("MCP unavailable"),
+    }
+    _install_fake_mcp(monkeypatch, state)
+
     server = mcp_client.MCPServerConfig(name="core", url="http://mcp.local")
     mcp_client._servers["core"] = server
     mcp_client._tools["confirm_order"] = mcp_client.MCPTool(name="confirm_order", server="core")
 
-    async def fake_http_request(
-        requested_server: mcp_client.MCPServerConfig,
-        method: str,
-        params: dict[str, Any],
-    ) -> dict[str, Any]:
-        raise RuntimeError("MCP unavailable")
-
-    monkeypatch.setattr(mcp_client, "_http_request", fake_http_request)
-
     assert _run(mcp_client.call_tool("confirm_order", {"order_id": "ORD-1"})) == {
         "error": "MCP unavailable"
     }
-
-
-class _FakeResponse:
-    """Async context manager emulating the aiohttp response subset we use."""
-
-    def __init__(self, status: int, headers: dict[str, str], payload: dict[str, Any]) -> None:
-        self.status = status
-        self.headers = headers
-        self._payload = payload
-        self.content: list[bytes] = []
-
-    async def __aenter__(self) -> "_FakeResponse":
-        return self
-
-    async def __aexit__(self, *args: object) -> None:
-        return None
-
-    def raise_for_status(self) -> None:
-        if self.status >= 400:
-            raise mcp_client.aiohttp.ClientError(f"HTTP {self.status}")
-
-    async def json(self) -> dict[str, Any]:
-        return self._payload

--- a/smart-kiosk-assistant/rag-service/tests/test_mcp_client.py
+++ b/smart-kiosk-assistant/rag-service/tests/test_mcp_client.py
@@ -129,7 +129,7 @@ def test_call_tool_times_out(monkeypatch, reset_mcp_state) -> None:
     }
     _install_fake_mcp(monkeypatch, state)
 
-    server = mcp_client.MCPServerConfig(name="core", url="http://mcp.local", timeout=0.001)
+    server = mcp_client.MCPServerConfig(name="core", url="http://mcp.local", timeout=0.01)
     mcp_client._servers["core"] = server
     mcp_client._tools["confirm_order"] = mcp_client.MCPTool(name="confirm_order", server="core")
 

--- a/smart-kiosk-assistant/rag-service/tests/test_ordering_agent.py
+++ b/smart-kiosk-assistant/rag-service/tests/test_ordering_agent.py
@@ -23,7 +23,19 @@ def test_make_mcp_callable_invokes_mcp_tool(monkeypatch) -> None:
     """The generated ADK callable delegates to mcp_client.call_tool."""
     fake_call_tool = AsyncMock(return_value={"status": "success", "result": "updated"})
     monkeypatch.setattr(ordering_agent, "call_tool", fake_call_tool)
-    mcp_tool = MCPTool(name="update_order", server="core", description="Add items")
+    mcp_tool = MCPTool(
+        name="update_order",
+        server="core",
+        description="Add items",
+        input_schema={
+            "type": "object",
+            "required": ["order_id", "items"],
+            "properties": {
+                "order_id": {"type": "string"},
+                "items": {"type": "array"},
+            },
+        },
+    )
 
     fn = OrderingAgent._make_mcp_callable("update_order", mcp_tool)
     result = _run(fn(order_id="ORD-1", items=[{"product_id": "coke", "quantity": 1}]))
@@ -34,7 +46,8 @@ def test_make_mcp_callable_invokes_mcp_tool(monkeypatch) -> None:
         {"order_id": "ORD-1", "items": [{"product_id": "coke", "quantity": 1}]},
     )
     assert fn.__name__ == "update_order"
-    assert fn.__schema__["name"] == "update_order"
+    assert "order_id" in fn.__signature__.parameters
+    assert "items" in fn.__signature__.parameters
 
 
 @pytest.mark.parametrize(
@@ -96,5 +109,8 @@ class _FakeRunner:
             reply = "How can I help?"
 
         for tool_name in tools:
-            yield SimpleNamespace(tool_call=SimpleNamespace(name=tool_name), content=None)
+            yield SimpleNamespace(
+                partial=False,
+                content=SimpleNamespace(parts=[SimpleNamespace(function_call=SimpleNamespace(name=tool_name))]),
+            )
         yield SimpleNamespace(tool_call=None, content=SimpleNamespace(parts=[SimpleNamespace(text=reply)]))


### PR DESCRIPTION
## Summary

This PR upgrades the RAG service to support transformers 5.3.0 and updates the dependent packages required for compatibility.

### Dependency updates

- transformers: 4.52.4 → 5.3.0
- optimum-intel: 1.24.0 → 2.1.0
- optimum: 1.26.1 → 2.3.0
- sentence-transformers: 3.0.1 → 5.2.0
- tokenizers: 0.21.4 → 0.22.2
- huggingface-hub: 0.34.4 → 1.21.0
- openvino-tokenizers: pinned to 2026.1.0.0

### Validation

- Container build succeeded.
- OpenVINO model export succeeded.
- Embedding component validation passed.
- Reranker validation passed.
- Retrieval pipeline validation passed.
- OVMS integration validation passed.
- End-to-end RAG pipeline validation passed.

### Additional work

The existing MCP, ordering-agent, and knowledge-lookup tests were updated to align with the current implementation.