### PR TITLE
Update DLStreamer base image to 2026.2.0-ubuntu24-rc1

### DIFF
--- a/smart-kiosk-assistant/identity-service/Dockerfile
+++ b/smart-kiosk-assistant/identity-service/Dockerfile
@@ -3,7 +3,7 @@
 # Base image bundles Intel OpenVINO + DL Streamer + GStreamer, matching the
 # gvadetect/gvaclassify pipelines and providing the OpenVINO runtime used for
 # face/voice embedding extraction (Phase 4+).
-FROM intel/dlstreamer:2026.1.0-ubuntu24
+FROM intel/dlstreamer:2026.2.0-ubuntu24-rc1
 
 # The dlstreamer image runs as a non-root user; switch to root to install deps.
 USER root

--- a/smart-kiosk-assistant/identity-service/README.md
+++ b/smart-kiosk-assistant/identity-service/README.md
@@ -175,7 +175,7 @@ still boots (`inference_ready=false`); `verify`/`register` report *not ready*.
 ```
 identity-service/
 ├── main.py                         # FastAPI app + endpoints + lifespan
-├── Dockerfile                      # FROM intel/dlstreamer:2026.1.0-ubuntu24
+├── Dockerfile                      # FROM intel/dlstreamer:2026.2.0-ubuntu24-rc1
 ├── requirements.txt
 ├── identity_core/
 │   ├── config.py                   # typed Settings (YAML + env)

--- a/smart-kiosk-assistant/identity-service/requirements.txt
+++ b/smart-kiosk-assistant/identity-service/requirements.txt
@@ -1,7 +1,7 @@
 # identity-service runtime dependencies.
 #
 # NOTE: OpenVINO, GStreamer and DL Streamer are provided by the base image
-# (intel/dlstreamer:2026.1.0-ubuntu24), so they are intentionally NOT pinned
+# (intel/dlstreamer:2026.2.0-ubuntu24-rc1), so they are intentionally NOT pinned
 # here.  faiss/opencv/numpy/etc. are added in Phase 3–4 as the pipeline lands.
 fastapi==0.116.1
 uvicorn==0.35.0

--- a/smart-kiosk-assistant/queue-service/docker/Dockerfile
+++ b/smart-kiosk-assistant/queue-service/docker/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-FROM intel/dlstreamer:2026.1.0-ubuntu24
+FROM intel/dlstreamer:2026.2.0-ubuntu24-rc1
 
 ARG APP_UID=1000
 ARG APP_GID=1000

--- a/smart-kiosk-assistant/queue-service/requirements.txt
+++ b/smart-kiosk-assistant/queue-service/requirements.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # GStreamer, the gva* elements, and OpenVINO are provided by the
-# intel/dlstreamer:2026.1.0-ubuntu24 base image and are NOT installed here.
+# intel/dlstreamer:2026.2.0-ubuntu24-rc1 base image and are NOT installed here.
 
 PyYAML==6.0.2
 numpy==1.26.4

--- a/smart-kiosk-assistant/queue-service/src/model_manager.py
+++ b/smart-kiosk-assistant/queue-service/src/model_manager.py
@@ -9,7 +9,7 @@ YOLO11) purely through configuration: ``pipeline.py`` only ever reads
 ``ir_path``/``proc_path``, while this module resolves *how* the IR is
 obtained. The ``omz`` provider downloads the pre-converted IR directly from the
 Intel Open Model Zoo storage server (the same artifact ``omz_downloader``
-fetches), because the ``intel/dlstreamer:2026.1.0-ubuntu24`` image ships neither
+fetches), because the ``intel/dlstreamer:2026.2.0-ubuntu24-rc1`` image ships neither
 the OMZ CLI tools nor ``openvino-dev``.
 """
 import logging

--- a/smart-kiosk-assistant/rag-service/Dockerfile
+++ b/smart-kiosk-assistant/rag-service/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-FROM intel/dlstreamer:2026.1.0-ubuntu24
+FROM intel/dlstreamer:2026.2.0-ubuntu24-rc1
 
 ARG APP_UID=1000
 ARG APP_GID=1000


### PR DESCRIPTION
## Changes

- Updated DLStreamer base image:
  - From: `intel/dlstreamer:2026.1.0-ubuntu24`
  - To: `intel/dlstreamer:2026.2.0-ubuntu24-rc1`
- Updated the following Dockerfiles:
  - `identity-service/Dockerfile`
  - `queue-service/docker/Dockerfile`
  - `rag-service/Dockerfile`
- Updated related documentation/comments to reflect the new DLStreamer image version.

## Validation

- Rebuilt all affected Docker images successfully.
- Started the Smart Kiosk Assistant application successfully.
- Verified all core service health checks passed.
- Performed end-to-end Voice Enabled Interaction validation.
- Verified Speech-to-Text, RAG processing, and Text-to-Speech functionality after the image update.