### PR TITLE
docs: update kiosk NPU configuration support (includes queue-service fix)

### DIFF
--- a/smart-kiosk-assistant/configs/audio-analyzer/config.yaml
+++ b/smart-kiosk-assistant/configs/audio-analyzer/config.yaml
@@ -91,7 +91,13 @@ models:
   diarization: # Only applicable when models.asr.diarization is set to True
     provider: "huggingface"
     name: "pyannote/speaker-diarization-3.1"
-    device: CPU  # CPU or GPU
+    # CPU only in the currently deployed Kiosk image. This PyTorch/SpeechBrain
+    # component is loaded via torch.device(<value>); PyTorch has no "gpu"
+    # device string (Intel GPU needs "xpu", which this component does not
+    # use) and no "npu" string at all, so GPU/NPU fail at load time and
+    # diarization is disabled for the session (ASR keeps working). See
+    # docs/user-guide/get-started/configuration.md#audio-analyzer-diarization-device-configyaml.
+    device: CPU
     models_base_path: "models"
 
     # ── Clustering aggressiveness (single-mic kiosk tuning) ────────────────

--- a/smart-kiosk-assistant/docs/user-guide/get-started/configuration.md
+++ b/smart-kiosk-assistant/docs/user-guide/get-started/configuration.md
@@ -71,8 +71,15 @@ Each model-hosting service reads its device from a pinned config file:
 The supported devices for each model are listed in the
 [Supported / validated models](#supported--validated-models) table above.
 
-Use uppercase device names (`CPU`, `GPU`, `NPU`). `rag-service` expects
-them as quoted strings; `audio-analyzer` and `text-to-speech` unquoted.
+Use uppercase device names (`CPU`, `GPU`, and — for `audio-analyzer` ASR and
+`queue-service` only — `NPU`). `rag-service` expects them as quoted strings;
+`audio-analyzer` and `text-to-speech` unquoted.
+
+> [!IMPORTANT]
+> **`text-to-speech` does not support `NPU`.** `models.tts.device` only
+> accepts `CPU`/`GPU` (see `configs/text-to-speech/config.yaml`); there is no
+> NPU device mapping for this service in `docker-compose.yml`. Do not set
+> `models.tts.device: NPU` — it is not a supported configuration.
 
 After editing, restart the affected service and confirm OpenVINO picked
 the device:
@@ -248,6 +255,130 @@ If `GPU` or `NPU` is configured and unavailable on the host,
 `make check-env` fails before any container startup. The stack does not
 silently fall back to another device.
 
+## Audio Analyzer Diarization Device (`config.yaml`)
+
+Diarization (`models.diarization.device`) is a **separate component from ASR**
+(see [ASR Support Matrix](#asr-support-matrix) above) with its own,
+more limited device support. Do not assume ASR's `CPU`/`GPU`/`NPU` support
+applies to diarization — it does not.
+
+> [!IMPORTANT]
+> **In the currently released Kiosk image, diarization only supports `CPU`.**
+> The diarizer (`pyannote/speaker-diarization-3.1`, a PyTorch/SpeechBrain
+> model) is loaded with `torch.device(<configured value>)`. PyTorch has no
+> `"gpu"` device string (Intel GPU support in PyTorch requires `"xpu"`, which
+> this component does not use) and no `"npu"` device string at all. Setting
+> `device: GPU` or `device: NPU` is **accepted by the config schema** but
+> fails at diarizer-load time with an error like:
+> ```
+> Expected one of cpu, cuda, ipu, xpu, ... device type at start of device string: gpu
+> ```
+> This is **non-fatal**: the failure is caught, logged as a warning, and
+> diarization is disabled for that session — the container stays healthy and
+> ASR keeps working, but speaker labels are not produced.
+>
+> **Use `device: CPU` for diarization.** Do not configure `GPU` or `NPU` for
+> `models.diarization.device` — they do not work in this image and will
+> silently disable diarization rather than accelerate it.
+
+An OpenVINO-backed diarization path that genuinely supports `GPU`/`NPU`
+exists in a newer upstream `edge-ai-libraries` `audio-analyzer` checkout,
+but **is not part of the currently released Kiosk image** covered by this
+document. Do not configure `GPU`/`NPU` for diarization based on that
+upstream code until a Kiosk image that includes it is released.
+
+## Queue Service Device (`QUEUE_DEVICE`)
+
+`queue-service` runs the YOLO26 person detector through a DLStreamer
+(`gvainference`) pipeline. The inference device is controlled by
+`model.device` in `queue-service/conf/queue-config.yaml`, and can be
+overridden without editing that file via `QUEUE_DEVICE` in `.env`
+(mapped by `docker-compose.yml` to `QUEUE_SERVICE__MODEL__DEVICE`, read by
+`queue-service/src/config_loader.py`).
+
+- Default: `QUEUE_DEVICE=CPU` — always available, no extra device mapping
+  needed.
+- `QUEUE_DEVICE=GPU` / `QUEUE_DEVICE=NPU` — supported, using the same
+  `/dev/dri` and `ACCEL_MOUNT_PATH`-driven `/dev/accel` mapping described
+  under [Audio Analyzer ASR Provider/Device](#audio-analyzer-asr-providerdevice-configyaml)
+  above. For NPU, set `ACCEL_MOUNT_PATH` to the host NPU device node
+  (auto-detected by `make up`) before starting `queue-service`.
+
+Verify the configured device actually reached the pipeline:
+
+```bash
+docker logs queue-service 2>&1 | grep "gvainference model"
+# Expected: ... gvainference model=... device=NPU ...  (or CPU/GPU, matching QUEUE_DEVICE)
+```
+
+> Editing `queue-config.yaml`'s `model.device` directly also works and takes
+> precedence in the same way as any other YAML default — `QUEUE_DEVICE` only
+> needs to be set when you want to override it without touching the file.
+
+## Identity Service Device (`IDENTITY_DEVICE`)
+
+`identity-service` performs face detection/re-identification
+(`face-detection-retail-0005`, `face-reidentification-retail-0095`) and
+voice-print embedding (`ecapa-tdnn-voice`) — all three are **OpenVINO IR
+models**, loaded via `openvino.Core().compile_model(model, device)`, and
+`IDENTITY_DEVICE` is correctly wired end-to-end from `.env` through
+`docker-compose.yml` to the OpenVINO compile call. The device-selection
+code itself has no bug and no model-format limitation.
+
+> [!IMPORTANT]
+> **Identity Service currently supports `CPU`/`GPU` in the Kiosk
+> deployment.** Although the face detection and re-identification models
+> use OpenVINO IR, `NPU` is currently unsupported because the
+> `identity-service` container does not have access to the NPU device:
+> `docker-compose.yml` only mounts `/dev/dri` (for `GPU`) for this service —
+> there is no `ACCEL_MOUNT_PATH`/`/dev/accel` mapping, unlike
+> `audio-analyzer` and `queue-service`. Setting `IDENTITY_DEVICE=NPU` is
+> currently accepted without validation/rejection, but OpenVINO would never
+> see an NPU device inside the container.
+>
+> Additionally, the face/voice model files are **not downloaded by
+> default** — run `./setup_models.sh --identity` first. Without them, the
+> face/voice engines stay disabled (`inference_ready=false`) regardless of
+> the configured device, independent of the NPU passthrough gap above.
+>
+> **Do not configure `IDENTITY_DEVICE=NPU` for the current deployment.**
+> Use `IDENTITY_DEVICE=CPU` or `IDENTITY_DEVICE=GPU` instead. Enabling NPU
+> in the future would require adding NPU device passthrough/configuration
+> to `docker-compose.yml` for this service and validating the complete
+> inference path, similar to the existing `audio-analyzer`/`queue-service`
+> `ACCEL_MOUNT_PATH` mechanism.
+
+## OVMS-LLM / RAG Service Device (`TARGET_DEVICE`)
+
+`TARGET_DEVICE` controls the inference device for both `ovms-llm` (the LLM
+served by OpenVINO Model Server for the ordering agent) and `rag-service`'s
+own embedding/reranker components (`rag-service/config.yaml`'s
+`models.embedding.device` / `retrieval.reranker.device`, both driven from
+the same `.env` variable via `docker-compose.yml`).
+
+- **Currently supported:** `TARGET_DEVICE=CPU`, `TARGET_DEVICE=GPU`.
+- **Currently unsupported:** `TARGET_DEVICE=NPU`.
+
+> [!IMPORTANT]
+> **`TARGET_DEVICE=NPU` is currently unsupported for the OVMS deployment**
+> because the current `ovms-llm` container configuration does not expose
+> the NPU device (only `/dev/dri` is mapped; there is no `/dev/accel`
+> passthrough). OpenVINO inside the `ovms-llm` container does not detect an
+> NPU (`Available devices for Open VINO: CPU, GPU`). Setting
+> `TARGET_DEVICE=NPU` may cause OVMS startup/inference-compilation failure
+> and container restart loops.
+>
+> **RAG service has a separate, independent NPU limitation.** When
+> `TARGET_DEVICE=NPU` is set, `rag-service` also attempts to initialize its
+> embedding/reranker components on NPU. The current RAG image does not
+> provide the required NPU compiler/runtime support
+> (`libopenvino_intel_npu_compiler.so` is missing), therefore NPU is
+> currently unsupported for the RAG service as well — independent of
+> whether `ovms-llm` itself is healthy.
+>
+> **Use `TARGET_DEVICE=CPU` or `TARGET_DEVICE=GPU`.** Do not configure
+> `TARGET_DEVICE=NPU` for the current OVMS/RAG deployment.
+
 ## Environment Variables
 
 kiosk-core has no config file. All settings are controlled through environment variables.
@@ -322,7 +453,29 @@ Session parameters (chunk duration, silence threshold, etc.) can also be provide
 This section provides a complete step-by-step workflow to run the Smart Kiosk Assistant with Intel NPU acceleration for Whisper ASR.
 
 > **Which services support NPU?**
-> Only `audio-analyzer` supports NPU (`provider: openvino, device: NPU`). All other services use CPU (kiosk-core, rag-service, text-to-speech) or GPU (ovms-llm). Do not set NPU on other services — they will fail to start.
+> `audio-analyzer` ASR (`provider: openvino, device: NPU`) and `queue-service`
+> (`QUEUE_DEVICE=NPU`) support NPU — see
+> [Queue Service Device](#queue-service-device-queue_device) above.
+> `audio-analyzer` diarization does **not** (see
+> [Audio Analyzer Diarization Device](#audio-analyzer-diarization-device-configyaml)),
+> `identity-service` does **not** currently (missing NPU device passthrough —
+> see [Identity Service Device](#identity-service-device-identity_device)),
+> `ovms-llm`/`rag-service` do **not** currently (missing NPU device
+> passthrough for `ovms-llm`, missing NPU compiler library for `rag-service`
+> — see [OVMS-LLM / RAG Service Device](#ovms-llm--rag-service-device-target_device)),
+> and `text-to-speech` does not support NPU at all. Do not set NPU on the
+> unsupported services/components — they will either fail to start or
+> silently disable the affected feature.
+>
+> | Component | CPU | GPU | NPU |
+> |---|---|---|---|
+> | Queue Service (`QUEUE_DEVICE`) | Yes | Yes | Yes |
+> | Identity Service (`IDENTITY_DEVICE`) | Yes | Yes | No — missing NPU device passthrough |
+> | OVMS-LLM (`TARGET_DEVICE`) | Yes | Yes | No — missing NPU device passthrough |
+> | RAG Service (`TARGET_DEVICE`) | Yes | Yes | No — missing NPU compiler library in image |
+> | Text-to-Speech (`models.tts.device`) | Yes | Yes | No |
+> | Audio Analyzer ASR (`models.asr.device`) | Yes | Yes | Yes (OpenVINO provider only — see [ASR Support Matrix](#asr-support-matrix)) |
+> | Audio Analyzer Diarization (`models.diarization.device`) | Yes | No — currently deployed configuration only supports CPU | No — currently deployed configuration only supports CPU |
 
 ### 1 — System requirements
 

--- a/smart-kiosk-assistant/docs/user-guide/troubleshooting.md
+++ b/smart-kiosk-assistant/docs/user-guide/troubleshooting.md
@@ -166,6 +166,42 @@ docker logs audio-analyzer
 curl http://localhost:8010/health
 ```
 
+### `TARGET_DEVICE=NPU` Causes OVMS/RAG to Restart-Loop
+
+If `TARGET_DEVICE=NPU` is configured for the current OVMS/RAG deployment,
+`ovms-llm` and `rag-service` may fail during startup because NPU is not
+currently supported in the deployed configuration. This can result in
+unhealthy containers or restart loops:
+
+- `ovms-llm`: the container only has `/dev/dri` mapped (no `/dev/accel`
+  passthrough), so OpenVINO inside the container does not detect an NPU
+  (`Available devices for Open VINO: CPU, GPU`). Forcing `TARGET_DEVICE=NPU`
+  causes an OpenVINO compilation failure and the container restarts
+  repeatedly under `restart: unless-stopped`.
+- `rag-service`: fails independently, for a different reason — its
+  embedding/reranker components also pick up `TARGET_DEVICE=NPU` and the
+  current RAG image does not provide the required NPU compiler/runtime
+  library (`libopenvino_intel_npu_compiler.so`), causing the service's
+  startup to fail and restart-loop even if `ovms-llm` were healthy.
+
+Set `TARGET_DEVICE=CPU` or `TARGET_DEVICE=GPU` in `.env` and recreate both
+services:
+
+```bash
+docker compose up -d --force-recreate ovms-llm rag-service
+docker inspect ovms-llm rag-service --format '{{.Name}}: {{.State.Status}} RestartCount={{.RestartCount}}'
+```
+
+### `IDENTITY_DEVICE=NPU` Is Not Supported
+
+`IDENTITY_DEVICE=NPU` is currently unsupported because the
+`identity-service` container does not expose the NPU device
+(`docker-compose.yml` only maps `/dev/dri` for this service, not
+`/dev/accel`). Setting `IDENTITY_DEVICE=NPU` will not cause a crash, but
+OpenVINO will never see an NPU device inside the container. Use
+`IDENTITY_DEVICE=CPU` or `IDENTITY_DEVICE=GPU` instead — see
+[Identity Service Device](./get-started/configuration.md#identity-service-device-identity_device).
+
 ## Permission Errors on Mounted Folders
 
 Every container runs as UID/GID `1000:1000` (baked into each image).

--- a/smart-kiosk-assistant/queue-service/src/config_loader.py
+++ b/smart-kiosk-assistant/queue-service/src/config_loader.py
@@ -89,20 +89,31 @@ def _dict_to_namespace(value):
     return value
 
 
-def load_config_dict(path=DEFAULT_CONFIG_PATH):
-    """Load ``path`` and apply ``QUEUE_SERVICE__`` env overrides.
+def load_config_dict(path=None):
+    """Load a queue-config YAML file and apply ``QUEUE_SERVICE__`` env overrides.
 
     Returns the plain (dict-of-dicts) form rather than the ``SimpleNamespace``
     used by :func:`load_config`, for callers that index the config with
     ``[...]``/``.get(...)`` (e.g. ``pipeline.py``'s element-property builders)
     instead of attribute access.
+
+    Path precedence (highest to lowest):
+      1. ``path`` — an explicit path supplied by the caller (e.g.
+         ``QueuePipeline(conf_dir=...)``) always wins; it is never
+         overridden by the environment.
+      2. ``QUEUE_SERVICE_CONFIG_PATH`` — used only when the caller relies on
+         the default path (``path`` omitted), so the env var can still
+         redirect the *default* config location.
+      3. ``DEFAULT_CONFIG_PATH`` — the built-in fallback.
     """
-    path = _resolve_path(os.environ.get(CONFIG_PATH_ENV, path))
+    if path is None:
+        path = os.environ.get(CONFIG_PATH_ENV, DEFAULT_CONFIG_PATH)
+    path = _resolve_path(path)
     data = _load_yaml_file(path)
     return _apply_env_overrides(data)
 
 
-def load_config(path=DEFAULT_CONFIG_PATH):
+def load_config(path=None):
     return _dict_to_namespace(load_config_dict(path))
 
 

--- a/smart-kiosk-assistant/queue-service/src/config_loader.py
+++ b/smart-kiosk-assistant/queue-service/src/config_loader.py
@@ -89,11 +89,21 @@ def _dict_to_namespace(value):
     return value
 
 
-def load_config(path=DEFAULT_CONFIG_PATH):
+def load_config_dict(path=DEFAULT_CONFIG_PATH):
+    """Load ``path`` and apply ``QUEUE_SERVICE__`` env overrides.
+
+    Returns the plain (dict-of-dicts) form rather than the ``SimpleNamespace``
+    used by :func:`load_config`, for callers that index the config with
+    ``[...]``/``.get(...)`` (e.g. ``pipeline.py``'s element-property builders)
+    instead of attribute access.
+    """
     path = _resolve_path(os.environ.get(CONFIG_PATH_ENV, path))
     data = _load_yaml_file(path)
-    data = _apply_env_overrides(data)
-    return _dict_to_namespace(data)
+    return _apply_env_overrides(data)
+
+
+def load_config(path=DEFAULT_CONFIG_PATH):
+    return _dict_to_namespace(load_config_dict(path))
 
 
 # Load once and expose.

--- a/smart-kiosk-assistant/queue-service/src/pipeline.py
+++ b/smart-kiosk-assistant/queue-service/src/pipeline.py
@@ -23,6 +23,8 @@ from urllib.parse import urlparse
 import gi
 import yaml
 
+from config_loader import load_config_dict
+
 gi.require_version("Gst", "1.0")
 gi.require_version("GstVideo", "1.0")
 from gi.repository import GLib, Gst, GstVideo  # noqa: E402  (must follow require_version)
@@ -133,13 +135,17 @@ _SOURCE_ELEMENT_NAME = "queue_source"
 class QueuePipeline:
     """Builds and runs the DLStreamer queue-service pipeline.
 
-    Configuration is read directly from the YAML files under ``conf/``
-    because the shared ``config_loader`` is not implemented yet.
+    ``queue-config.yaml`` is loaded through the shared ``config_loader``
+    module so ``QUEUE_SERVICE__*`` environment overrides (e.g.
+    ``QUEUE_SERVICE__MODEL__DEVICE``, wired from ``QUEUE_DEVICE`` in
+    ``docker-compose.yml``/``.env``) reach the actual pipeline element
+    properties. ``pipeline.yaml`` (the element graph shape) has no
+    overridable settings and is loaded as plain YAML.
     """
 
     def __init__(self, conf_dir: Path | str | None = None) -> None:
         self._conf_dir = Path(conf_dir) if conf_dir else CONF_DIR
-        self._config = self._load_yaml(self._conf_dir / "queue-config.yaml")
+        self._config = load_config_dict(str(self._conf_dir / "queue-config.yaml"))
         self._pipeline_def = self._load_yaml(self._conf_dir / "pipeline.yaml")
 
         source_cfg = self._config.get("source", {})

--- a/smart-kiosk-assistant/queue-service/tests/test_config_loader.py
+++ b/smart-kiosk-assistant/queue-service/tests/test_config_loader.py
@@ -1,0 +1,116 @@
+"""Unit tests for config_loader.py -- path precedence and env overrides.
+
+Covers the Copilot review fix for ITEP-95364: an explicit ``path`` argument
+(e.g. from ``QueuePipeline(conf_dir=...)``) must take precedence over
+``QUEUE_SERVICE_CONFIG_PATH``, while the env var must still redirect the
+*default* path when no explicit path is supplied.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+CONFIG_LOADER_MODULE = "config_loader"
+
+
+@pytest.fixture()
+def config_loader(monkeypatch):
+    """Import a fresh config_loader module with no QUEUE_SERVICE_* env vars set.
+
+    The module-level ``config = load_config()`` at import time means a
+    stale module (imported by an earlier test with different env vars)
+    would poison other tests, so each test gets a clean re-import.
+    """
+    for key in list(os.environ):
+        if key.startswith("QUEUE_SERVICE"):
+            monkeypatch.delenv(key, raising=False)
+
+    sys.modules.pop(CONFIG_LOADER_MODULE, None)
+    module = importlib.import_module(CONFIG_LOADER_MODULE)
+    yield module
+    sys.modules.pop(CONFIG_LOADER_MODULE, None)
+
+
+def _write_config(path: Path, device: str) -> None:
+    path.write_text(
+        textwrap.dedent(
+            f"""\
+            model:
+              device: "{device}"
+            """
+        )
+    )
+
+
+def test_default_path_honors_config_path_env(tmp_path, monkeypatch, config_loader):
+    """No explicit path -> QUEUE_SERVICE_CONFIG_PATH should redirect the load."""
+    custom_config = tmp_path / "custom-queue-config.yaml"
+    _write_config(custom_config, device="GPU")
+    monkeypatch.setenv(config_loader.CONFIG_PATH_ENV, str(custom_config))
+
+    result = config_loader.load_config_dict()
+
+    assert result["model"]["device"] == "GPU"
+
+
+def test_explicit_path_overrides_config_path_env(tmp_path, monkeypatch, config_loader):
+    """An explicit path (e.g. from QueuePipeline(conf_dir=...)) must win over
+    QUEUE_SERVICE_CONFIG_PATH, matching the Copilot review requirement."""
+    explicit_config = tmp_path / "explicit-queue-config.yaml"
+    _write_config(explicit_config, device="CPU")
+
+    other_config = tmp_path / "other-queue-config.yaml"
+    _write_config(other_config, device="GPU")
+    monkeypatch.setenv(config_loader.CONFIG_PATH_ENV, str(other_config))
+
+    result = config_loader.load_config_dict(str(explicit_config))
+
+    assert result["model"]["device"] == "CPU"
+
+
+def test_explicit_path_used_by_load_config_namespace_form(tmp_path, monkeypatch, config_loader):
+    """load_config() (SimpleNamespace form) must behave consistently with
+    load_config_dict() for the same explicit-path precedence rule."""
+    explicit_config = tmp_path / "explicit-queue-config.yaml"
+    _write_config(explicit_config, device="CPU")
+
+    other_config = tmp_path / "other-queue-config.yaml"
+    _write_config(other_config, device="GPU")
+    monkeypatch.setenv(config_loader.CONFIG_PATH_ENV, str(other_config))
+
+    result = config_loader.load_config(str(explicit_config))
+
+    assert result.model.device == "CPU"
+
+
+def test_queue_service_model_device_override_applies(tmp_path, monkeypatch, config_loader):
+    """Normal QUEUE_SERVICE__MODEL__DEVICE override (the QUEUE_DEVICE path)
+    must still work regardless of path precedence changes."""
+    explicit_config = tmp_path / "queue-config.yaml"
+    _write_config(explicit_config, device="CPU")
+    monkeypatch.setenv("QUEUE_SERVICE__MODEL__DEVICE", "NPU")
+
+    result = config_loader.load_config_dict(str(explicit_config))
+
+    assert result["model"]["device"] == "NPU"
+
+
+def test_queue_service_model_device_override_with_default_path(
+    tmp_path, monkeypatch, config_loader
+):
+    """QUEUE_SERVICE_CONFIG_PATH (default-path redirection) and
+    QUEUE_SERVICE__MODEL__DEVICE (value override) must compose correctly
+    when used together, with no explicit path supplied."""
+    custom_config = tmp_path / "custom-queue-config.yaml"
+    _write_config(custom_config, device="CPU")
+    monkeypatch.setenv(config_loader.CONFIG_PATH_ENV, str(custom_config))
+    monkeypatch.setenv("QUEUE_SERVICE__MODEL__DEVICE", "NPU")
+
+    result = config_loader.load_config_dict()
+
+    assert result["model"]["device"] == "NPU"


### PR DESCRIPTION
### Changes

- Fixed the queue-service configuration path issue so `QUEUE_DEVICE` environment variable overrides are correctly applied to the pipeline.
- Verified queue-service NPU inference successfully with `QUEUE_DEVICE=NPU`.
- Updated Audio Analyzer documentation with the current device support/limitations.
- Updated TTS documentation to clarify NPU is currently not supported.
- Updated Identity Service documentation:
  - Identity models use OpenVINO IR.
  - Documented the current NPU device-access limitation.
- Updated OVMS/RAG documentation:
  - Documented the current `TARGET_DEVICE=NPU` limitation.
  - Documented the NPU device-access and RAG NPU compiler library issues.
  - Added troubleshooting guidance for the resulting restart/bootloop behavior.