### PR TITLE
docs: add missing make init-env step to build-from-source.md (ITEP-95…

### DIFF
--- a/smart-kiosk-assistant/docs/user-guide/get-started/build-from-source.md
+++ b/smart-kiosk-assistant/docs/user-guide/get-started/build-from-source.md
@@ -46,6 +46,16 @@ plain `git clone` of `edge-ai-libraries` also works if you do not mind
 the extra files. Only the build flow needs `edge-ai-libraries` on disk
 — the pull flow (see [Run With Docker Compose](./run-container.md)) does not.
 
+## Create the Environment File
+
+`.env` is not committed to the repo. `docker-compose.yml` reads
+`REGISTRY`/`RELEASE_TAG` from it and falls back to `latest` if it's
+missing, so create it before building:
+
+```bash
+make init-env        # copies .env.example → .env
+```
+
 ## Download the LLM Model for OVMS
 
 Before building or starting the stack, download the Qwen3-4B model that
@@ -71,8 +81,9 @@ HuggingFace Hub and updates `OVMS_MODEL_NAME`, `TARGET_DEVICE`, and
 The top-level [docker-compose.yml](https://github.com/intel-retail/voice-enabled-interactions/blob/main/smart-kiosk-assistant/docker-compose.yml)
 declares both `image:` and `build:` for each of the five services: `audio-analyzer`,
 `text-to-speech`, `rag-service`, `kiosk-core`, and `kiosk-ui`. Both
-`REGISTRY` and `RELEASE_TAG` are read from [.env](https://github.com/intel-retail/voice-enabled-interactions/blob/main/smart-kiosk-assistant/.env)
-(defaults: `REGISTRY=intel`, committed `RELEASE_TAG` pins the current release).
+`REGISTRY` and `RELEASE_TAG` are read from `.env` (created in
+[Create the Environment File](#create-the-environment-file) above;
+defaults: `REGISTRY=intel`, `RELEASE_TAG` pins the current release).
 
 `docker compose build` rebuilds each service from source and tags the
 result as the same `${REGISTRY}/<svc>:${RELEASE_TAG}` reference used by


### PR DESCRIPTION
…440)

build-from-source.md never instructed readers to create .env before building, so docker compose build/up fell back to :latest tags (RELEASE_TAG unset). setup_models.sh's update_env() only appends OVMS_MODEL_NAME/TARGET_DEVICE/RENDER_GID via >>, so on a missing .env it does not backfill RELEASE_TAG/REGISTRY either.

Added a 'Create the Environment File' step (make init-env) right after cloning, matching the step already present in get-started.md. Verified: starting from a fresh .env.example, make init-env produces RELEASE_TAG=2026.2.0-rc2 as expected.